### PR TITLE
Fixed project dependency to HWLOC

### DIFF
--- a/src/CMake/thirdparty/SetupHwloc.cmake
+++ b/src/CMake/thirdparty/SetupHwloc.cmake
@@ -35,6 +35,8 @@ if(NOT HWLOC_INCLUDE_DIRS AND NOT HWLOC_LIBRARY)
     MESSAGE(STATUS "Downloading and building Hwloc from source")
     include(CMake/SetupExternalProjects.cmake)
 
+    set(HWLOC_EXT TRUE)
+
     message(STATUS "ExternalProject Hwloc")
     message(STATUS "  HWLOC_INCLUDE_DIRS = ${HWLOC_INCLUDE_DIRS}")
     message(STATUS "  HWLOC_LIBRARY = ${HWLOC_LIBRARY}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIBMSR_SOURCES
 add_library(msr SHARED ${LIBMSR_SOURCES})
 target_link_libraries(msr ${HWLOC_LIBRARY})
 target_link_libraries(msr m)
+add_dependencies(msr libhwloc)
 
 #
 # Add static library with same base name as the dynamic lib.
@@ -32,6 +33,7 @@ add_library(msr-static STATIC ${LIBMSR_SOURCES})
 target_link_libraries(msr-static ${HWLOC_LIBRARY})
 target_link_libraries(msr-static m)
 set_target_properties(msr-static PROPERTIES OUTPUT_NAME "msr")
+add_dependencies(msr-static libhwloc)
 
 #
 # Install target should install the two library targets above.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,9 @@ set(LIBMSR_SOURCES
 add_library(msr SHARED ${LIBMSR_SOURCES})
 target_link_libraries(msr ${HWLOC_LIBRARY})
 target_link_libraries(msr m)
-add_dependencies(msr libhwloc)
+if(HWLOC_EXT)
+    add_dependencies(msr libhwloc)
+endif()
 
 #
 # Add static library with same base name as the dynamic lib.
@@ -33,7 +35,9 @@ add_library(msr-static STATIC ${LIBMSR_SOURCES})
 target_link_libraries(msr-static ${HWLOC_LIBRARY})
 target_link_libraries(msr-static m)
 set_target_properties(msr-static PROPERTIES OUTPUT_NAME "msr")
-add_dependencies(msr-static libhwloc)
+if(HWLOC_EXT)
+    add_dependencies(msr-static libhwloc)
+endif()
 
 #
 # Install target should install the two library targets above.


### PR DESCRIPTION
Hi Stephanie,

I have fixed the bug. The problem was on a missing dependency to hwloc. It was enough to add a dependency directive after the cmake targets. Now, the make process triggers the download/compilation stage of hwloc before to compile the libmsr library.

From my side everything works!

Best,
Daniele